### PR TITLE
Image size and build time reduced.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,16 @@
-FROM alpine:latest
+FROM frolvlad/alpine-oraclejdk8:slim
 MAINTAINER daicho
-
-RUN apk --update add openjdk7 ttf-dejavu &&\
-    rm -rf /var/cache/apk/*
+CMD [""]
+ENTRYPOINT ["java", "-jar", "/usr/local/jenkins/jenkins.war"]
+EXPOSE 8080
 
 ENV JENKINS_HOME /usr/local/jenkins
 
-RUN mkdir -p /usr/local/jenkins
-RUN adduser -D -H -s /bin/sh jenkins 
-RUN chown -R jenkins:jenkins /usr/local/jenkins/
-ADD http://mirrors.jenkins-ci.org/war-stable/latest/jenkins.war /usr/local/jenkins/jenkins.war
-RUN chmod 644 /usr/local/jenkins/jenkins.war
+RUN \
+    mkdir -p /usr/local/jenkins ; \
+    adduser -D -H -s /bin/sh jenkins ; \
+    chown -R jenkins:jenkins /usr/local/jenkins/ ; \
+    wget http://mirrors.jenkins-ci.org/war-stable/latest/jenkins.war -O /usr/local/jenkins/jenkins.war; \
+    chmod 644 /usr/local/jenkins/jenkins.war
 
-ENTRYPOINT ["java", "-jar", "/usr/local/jenkins/jenkins.war"]
-EXPOSE 8080
-CMD [""]
+


### PR DESCRIPTION
JDK installation skipped in favor of prebuild Oracle JDK image;
RUN steps aggregated, so chmod doesn't produce extra layer.